### PR TITLE
build: create build script

### DIFF
--- a/common/build.sh
+++ b/common/build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+home_dir=`pwd` 
+folder=$1
+echo "$home_dir/packages/$folder"
+
+if [ -d "$home_dir/packages/$folder" ]; then
+ cd ./packages/$folder
+ npm run build
+
+ cd $home_dir
+ bundle_path="./packages/build/$folder.js"
+ touch $bundle_path
+ cp ./packages/$folder/build/direflowBundle.js $bundle_path
+else 
+ echo "Folder doesn't exist"
+ exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
  },
  "scripts": {
    "new-wc": "./common/new-wc.sh",
-   "tsc": "yarn workspaces run tsc"
+   "tsc": "yarn workspaces run tsc",
+   "build": "./common/build.sh",
+   "prebuild": "mkdir ./packages/build"
  },
  "devDependencies": {
   "typescript": "4.4.4"


### PR DESCRIPTION
When building a component, the js bundle will be copied to the packages/build folder using the script. From bundled js file, the container will load the component.